### PR TITLE
Add exif extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,12 @@ RUN apt-get update && apt-get install -y \
         libgd-dev && \
     docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
     docker-php-ext-install \
+        exif \
         gd \
         mysqli \
         pdo \
         pdo_mysql \
-        zip \
-        exif && \
+        zip && \
     a2enmod rewrite
 
 # Download installer script

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN apt-get update && apt-get install -y \
         mysqli \
         pdo \
         pdo_mysql \
-        zip && \
+        zip \
+        exif && \
     a2enmod rewrite
 
 # Download installer script

--- a/Dockerfile-installer
+++ b/Dockerfile-installer
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
         zlib1g-dev && \
     docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
     docker-php-ext-install \
+        exif \
         gd \
         mysqli \
         pdo \


### PR DESCRIPTION
Chevereto [uses the exif extension](https://github.com/Chevereto/Chevereto-Free/blob/67f2c926266979c779f002eef6d79c8cd111a57c/app/lib/classes/class.upload.php#L121) if available when uploading images to extract exif data. This pr simple enables the exif php extension.


With exif ext enabled:
```
root@chevereto-7fc7d8dc49-tfnws:/var/www/html# php -a
Interactive shell

php > print function_exists('read_exif_data') ? 'true' : 'false';
true
```